### PR TITLE
add arm64 support for Docker image

### DIFF
--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -31,5 +31,5 @@ jobs:
           context: .
           file: ./Dockerfile
           platforms: linux/amd64, linux/arm64
-          push: true
+          push: ${{ github.ref == 'refs/heads/main' }}
           tags: stratospheric/activemq-docker-image:latest

--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
         with:
-          platforms: arm64, amd64
+          platforms: arm64, amd64, arm64/v8
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -30,6 +30,6 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64, linux/arm64
+          platforms: linux/amd64, linux/arm64, linux/arm64/v8
           push: true
           tags: stratospheric/activemq-docker-image:latest

--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
         with:
-          platforms: arm64, amd64, arm64/v8
+          platforms: arm64, amd64
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -30,6 +30,6 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64, linux/arm64, linux/arm64/v8
+          platforms: linux/amd64, linux/arm64
           push: true
           tags: stratospheric/activemq-docker-image:latest

--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -18,11 +18,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+
       - name: Push to Docker Hub
         uses: docker/build-push-action@v2
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64 # currently fails with linux/arm64
+          platforms: linux/amd64, linux/arm64
           push: true
           tags: stratospheric/activemq-docker-image:latest

--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -9,11 +9,17 @@ jobs:
     steps:
       - name: Check out
         uses: actions/checkout@v2
-      -
-        name: Set up Docker Buildx
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: "arm64, amd64"
+
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      -
-        name: Login to DockerHub
+
+
+      - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
         with:
-          platforms: "arm64, amd64"
+          platforms: arm64, amd64
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -25,7 +25,7 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
 
-      - name: Push to Docker Hub
+      - name: Build Docker image and push to Docker Hub
         uses: docker/build-push-action@v2
         with:
           context: .

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,9 @@ ENV ACTIVEMQ_HOME /opt/activemq
 # See https://archive.apache.org/dist/activemq/5.15.14/apache-activemq-5.15.14-bin.tar.gz.sha512
 ENV SHA512_VAL=5708ed926988e4796a8badaed3dafd32bcbc47890169df2712568ad706858370b20e5cd9a4e3298521692151e63a5ac6d06866b3ad188aa0e36b28e370240d5c
 
-RUN mkdir -p /opt && \
+RUN apt update && \
+    apt install -f -y curl && \
+    mkdir -p /opt && \
     curl https://archive.apache.org/dist/activemq/$ACTIVEMQ_VERSION/$ACTIVEMQ-bin.tar.gz -o $ACTIVEMQ-bin.tar.gz
 
 RUN if [ "$SHA512_VAL" != "$(sha512sum $ACTIVEMQ-bin.tar.gz | awk '{print($1)}')" ];\

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,29 @@
 FROM eclipse-temurin:11-jre-focal
 
 LABEL org.opencontainers.image.authors="Björn Wilmsmann <bjoernkw@bjoernkw.com>, Philip Riecks <mail@philipriecks.de>"
-# Derived from https://github.com/njmittet/alpine-activemq
-# by Nils Jørgen Mittet <njmittet@gmail.com>
+# Derived from https://github.com/njmittet/alpine-activemq and https://github.com/rmohr/docker-activemq
+# by Nils Jørgen Mittet <njmittet@gmail.com> and Roman Mohr <roman@fenkhuber.at>
 
 ENV ACTIVEMQ_VERSION 5.15.14
 ENV ACTIVEMQ apache-activemq-$ACTIVEMQ_VERSION
 ENV ACTIVEMQ_HOME /opt/activemq
+# See https://archive.apache.org/dist/activemq/5.15.14/apache-activemq-5.15.14-bin.tar.gz.sha512
+ENV SHA512_VAL=5708ed926988e4796a8badaed3dafd32bcbc47890169df2712568ad706858370b20e5cd9a4e3298521692151e63a5ac6d06866b3ad188aa0e36b28e370240d5c
 
-RUN apt-get update && \
-    apt-get install -f -y curl && \
+RUN apt update && \
+    apt install -f -y curl && \
     mkdir -p /opt && \
-    curl -s -S https://archive.apache.org/dist/activemq/$ACTIVEMQ_VERSION/$ACTIVEMQ-bin.tar.gz | tar -xvz -C /opt && \
-    ln -s /opt/$ACTIVEMQ $ACTIVEMQ_HOME
+    curl https://archive.apache.org/dist/activemq/$ACTIVEMQ_VERSION/$ACTIVEMQ-bin.tar.gz -o $ACTIVEMQ-bin.tar.gz
 
-# Create app runtime user and group
-RUN groupadd activemq && \
+RUN if [ "$SHA512_VAL" != "$(sha512sum $ACTIVEMQ-bin.tar.gz | awk '{print($1)}')" ];\
+    then \
+        echo "sha512 values doesn't match! exiting."  && \
+        exit 1; \
+    fi;
+
+RUN tar xzf $ACTIVEMQ-bin.tar.gz -C  /opt && \
+    ln -s /opt/$ACTIVEMQ $ACTIVEMQ_HOME && \
+    groupadd activemq && \
     useradd -m -d $ACTIVEMQ_HOME -g activemq activemq && \
     chown -R activemq:activemq /opt/$ACTIVEMQ && \
     chown -h activemq:activemq $ACTIVEMQ_HOME 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,7 @@ ENV ACTIVEMQ_HOME /opt/activemq
 # See https://archive.apache.org/dist/activemq/5.15.14/apache-activemq-5.15.14-bin.tar.gz.sha512
 ENV SHA512_VAL=5708ed926988e4796a8badaed3dafd32bcbc47890169df2712568ad706858370b20e5cd9a4e3298521692151e63a5ac6d06866b3ad188aa0e36b28e370240d5c
 
-RUN apt update && \
-    apt install -f -y curl && \
-    mkdir -p /opt && \
+RUN mkdir -p /opt && \
     curl https://archive.apache.org/dist/activemq/$ACTIVEMQ_VERSION/$ACTIVEMQ-bin.tar.gz -o $ACTIVEMQ-bin.tar.gz
 
 RUN if [ "$SHA512_VAL" != "$(sha512sum $ACTIVEMQ-bin.tar.gz | awk '{print($1)}')" ];\
@@ -23,7 +21,7 @@ RUN if [ "$SHA512_VAL" != "$(sha512sum $ACTIVEMQ-bin.tar.gz | awk '{print($1)}')
 
 RUN file $ACTIVEMQ-bin.tar.gz
 
-RUN tar xzf $ACTIVEMQ-bin.tar.gz -C  /opt && \
+RUN tar xzf $ACTIVEMQ-bin.tar.gz -C /opt && \
     ln -s /opt/$ACTIVEMQ $ACTIVEMQ_HOME && \
     groupadd activemq && \
     useradd -m -d $ACTIVEMQ_HOME -g activemq activemq && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,8 @@ RUN if [ "$SHA512_VAL" != "$(sha512sum $ACTIVEMQ-bin.tar.gz | awk '{print($1)}')
         exit 1; \
     fi;
 
+RUN file $ACTIVEMQ-bin.tar.gz
+
 RUN tar xzf $ACTIVEMQ-bin.tar.gz -C  /opt && \
     ln -s /opt/$ACTIVEMQ $ACTIVEMQ_HOME && \
     groupadd activemq && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV ACTIVEMQ_HOME /opt/activemq
 ENV SHA512_VAL=5708ed926988e4796a8badaed3dafd32bcbc47890169df2712568ad706858370b20e5cd9a4e3298521692151e63a5ac6d06866b3ad188aa0e36b28e370240d5c
 
 RUN apt update && \
-    apt install -f -y curl && \
+    apt install -y curl && \
     mkdir -p /opt && \
     curl https://archive.apache.org/dist/activemq/$ACTIVEMQ_VERSION/$ACTIVEMQ-bin.tar.gz -o $ACTIVEMQ-bin.tar.gz
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,6 @@ RUN if [ "$SHA512_VAL" != "$(sha512sum $ACTIVEMQ-bin.tar.gz | awk '{print($1)}')
         exit 1; \
     fi;
 
-RUN file $ACTIVEMQ-bin.tar.gz
-
 RUN tar xzf $ACTIVEMQ-bin.tar.gz -C /opt && \
     ln -s /opt/$ACTIVEMQ $ACTIVEMQ_HOME && \
     groupadd activemq && \

--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
 # ActiveMQ Docker image
 ActiveMQ Classic 5.x Docker image for local development with the Stratospheric sample Todo application.
 
-This Docker image support `amd64`, `arm64`, `arm64/V8` platforms.
+This Docker image support `amd64` and `arm64` platforms:
+
+```
+docker pull --platform=linux/amd64 stratospheric/activemq-docker-image:latest
+docker pull --platform=linux/arm64 stratospheric/activemq-docker-image:latest
+```

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # ActiveMQ Docker image
-ActiveMQ Classic 5.x Docker image for local development with the Stratospheric sample Todo application
+ActiveMQ Classic 5.x Docker image for local development with the Stratospheric sample Todo application.
+
+This Docker image support `amd64` and `arm64` platforms.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # ActiveMQ Docker image
 ActiveMQ Classic 5.x Docker image for local development with the Stratospheric sample Todo application.
 
-This Docker image support `amd64` and `arm64` platforms.
+This Docker image support `amd64`, `arm64`, `arm64/V8` platforms.


### PR DESCRIPTION
To allow running Stratospheric locally on an `arm64` platform (e.g. MacBook with M1), we need to build the Docker image cross-platform.